### PR TITLE
ActiveRecord/Association Tests & Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gemspec
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
+#
+gem 'factory_girl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,9 +47,12 @@ GEM
     builder (3.2.3)
     concurrent-ruby (1.0.5)
     erubi (1.6.1)
+    factory_girl (4.8.0)
+      activesupport (>= 3.0.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
+    json (2.0.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -110,6 +113,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  factory_girl
+  json
   painted_rabbit!
   rails (~> 5.1.2)
   sqlite3

--- a/lib/painted_rabbit.rb
+++ b/lib/painted_rabbit.rb
@@ -1,5 +1,3 @@
-#Dir["#{File.dirname(__FILE__)}/painted_rabbit/*.rb"].each { |file| require file }
-#Dir["#{File.dirname(__FILE__)}/painted_rabbit/serializers/*.rb"].each { |file| require file }
 require_relative 'painted_rabbit/base'
 
 module PaintedRabbit

--- a/lib/painted_rabbit/base.rb
+++ b/lib/painted_rabbit/base.rb
@@ -34,63 +34,23 @@ module PaintedRabbit
     end
 
     def self.render(object, view: :default)
-      jsonify(hashify(object, view: view))
+      jsonify(prepare(object, view: view))
     end
 
-    def self.hashify(object, view:)
+    # This is the magic method that converts complex objects into a simple hash
+    # ready for JSON conversion
+    def self.prepare(object, view:)
       unless views.keys.include? view
         raise PaintedRabbitError, "View '#{view}' is not defined"
       end
-      output_hash = if object.respond_to? :each
-        if object.respond_to? :select # TODO: Change to more explicitely test for AR
-          select_columns = (active_record_attributes(object) &
-            render_fields(view).map(&:method)) +
-            required_lookup_attributes(object)
-          object = object.select(*select_columns)
-        end
-        object = include_associations(object, view: view)
-        object.map do |obj|
-          render_fields(view).each_with_object({}) { |field, hash|
-            hash[field.name] = field.serializer.call(field.method, obj, field.options)
-          }
+      prepared_object = select_columns(object, view: view)
+      prepared_object = include_associations(prepared_object, view: view)
+      if prepared_object.respond_to? :map
+        prepared_object.map do |obj|
+          object_to_hash(obj, view: view)
         end
       else
-        render_fields(view).each_with_object({}) { |field, hash|
-          hash[field.name] = field.serializer.call(field.method, object, field.options)
-        }
-      end
-    end
-
-    def self.include_associations(object, view:)
-      # TODO: Do we need to support more than `eager_load` ?
-      fields_to_include = associations(view).select { |a|
-        a.options[:include] != false
-      }.map(&:method)
-      if !fields_to_include.empty?
-        object.eager_load(*fields_to_include)
-      else
-        object
-      end
-    end
-
-    def self.active_record_attributes(object)
-      object.klass.column_names.map(&:to_sym)
-    end
-
-    def self.render_fields(view)
-      views[:identifier].values +
-        views[:default].merge(views[view]).values.sort_by(&:name)
-    end
-
-    # Find all the attributes required for includes & eager/pre-loading
-    def self.required_lookup_attributes(object)
-      # TODO: We may not need all four of these
-      lookup_values = (object.includes_values +
-        object.preload_values +
-        object.joins_values +
-        object.eager_load_values).uniq
-      lookup_values.map do |value|
-        object.reflections[value.to_s].foreign_key
+        object_to_hash(prepared_object, view: view)
       end
     end
 
@@ -115,6 +75,64 @@ module PaintedRabbit
 
     private
 
+    def self.object_to_hash(object, view:)
+      render_fields(view).each_with_object({}) do |field, hash|
+        hash[field.name] = field.serializer.call(field.method, object, field.options)
+      end
+    end
+    private_class_method :object_to_hash
+
+    def self.select_columns(object, view:)
+      unless object.is_a?(ActiveRecord::Base) && object.respond_to?(:klass)
+        return object
+      end
+      select_columns = (active_record_attributes(object) &
+        render_fields(view).map(&:method)) +
+        required_lookup_attributes(object)
+      object.select(*select_columns)
+    end
+    private_class_method :select_columns
+
+    def self.include_associations(object, view:)
+      unless object.is_a?(ActiveRecord::Base) && object.respond_to?(:klass)
+        return object
+      end
+      # TODO: Do we need to support more than `eager_load` ?
+      fields_to_include = associations(view).select { |a|
+        a.options[:include] != false
+      }.map(&:method)
+      if !fields_to_include.empty?
+        object.eager_load(*fields_to_include)
+      else
+        object
+      end
+    end
+    private_class_method :include_associations
+
+    def self.active_record_attributes(object)
+      object.klass.column_names.map(&:to_sym)
+    end
+    private_class_method :active_record_attributes
+
+    def self.render_fields(view)
+      views[:identifier].values +
+        views[:default].merge(views[view]).values.sort_by(&:name)
+    end
+    private_class_method :render_fields
+
+    # Find all the attributes required for includes & eager/pre-loading
+    def self.required_lookup_attributes(object)
+      # TODO: We may not need all four of these
+      lookup_values = (object.includes_values +
+        object.preload_values +
+        object.joins_values +
+        object.eager_load_values).uniq
+      lookup_values.map do |value|
+        object.reflections[value.to_s].foreign_key
+      end
+    end
+    private_class_method :required_lookup_attributes
+
     def self.jsonify(blob)
       if blob.respond_to? :to_json
         blob.to_json
@@ -122,20 +140,16 @@ module PaintedRabbit
         JSON.generate(blob)
       end
     end
-
-    # I had to test this, so a note for later, class level instance variables
-    # are not mutated at the parent class level when they are changed at the
-    # inherited class
-    def self.tracked_fields
-      @tracked_fields ||= []
-    end
+    private_class_method :jsonify
 
     def self.current_views
       @current_views ||= [:default]
     end
+    private_class_method :current_views
 
     def self.views
       @views ||= { identifier: {}, default: {} }
     end
+    private_class_method :views
   end
 end

--- a/lib/painted_rabbit/serializer.rb
+++ b/lib/painted_rabbit/serializer.rb
@@ -10,7 +10,7 @@ class PaintedRabbit::Serializer
     @_blah
   end
 
-  def call(field_name, object)
-    @block.call(field_name, object)
+  def call(field_name, object, options={})
+    @block.call(field_name, object, options)
   end
 end

--- a/lib/painted_rabbit/serializers/association_serializer.rb
+++ b/lib/painted_rabbit/serializers/association_serializer.rb
@@ -1,7 +1,8 @@
 class PaintedRabbit::AssociationSerializer < PaintedRabbit::Serializer
-  serialize do |association_name, object, options|
-    if object.class.respond_to? :serializer
-      object.class.serializer.render(object.public_send(association_name), options)
+  serialize do |association_name, object, options={}|
+    if options[:serializer]
+      view = options[:view] || :default
+      options[:serializer].hashify(object.public_send(association_name), view: view)
     else
       object.public_send(association_name)
     end

--- a/lib/painted_rabbit/serializers/association_serializer.rb
+++ b/lib/painted_rabbit/serializers/association_serializer.rb
@@ -2,7 +2,7 @@ class PaintedRabbit::AssociationSerializer < PaintedRabbit::Serializer
   serialize do |association_name, object, options={}|
     if options[:serializer]
       view = options[:view] || :default
-      options[:serializer].hashify(object.public_send(association_name), view: view)
+      options[:serializer].prepare(object.public_send(association_name), view: view)
     else
       object.public_send(association_name)
     end

--- a/painted_rabbit.gemspec
+++ b/painted_rabbit.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", "~> 5.1.2"
 
+  s.add_development_dependency "json"
+
   s.add_development_dependency "sqlite3"
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -27,8 +27,101 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
     ViewUserSerializer = Class.new(PaintedRabbit::Base) do
       identifier :id
       field :email
-      fields :last_name, :first_name
+
+      include_in :normal do
+        fields :last_name, :first_name
+      end
     end
+
+    user = create(:user)
+
+    expected_default_view = JSON.generate({
+      id: user.id,
+      email: user.email
+    })
+    assert_equal(expected_default_view, ViewUserSerializer.render(user))
+    expected_normal_view = JSON.generate({
+      id: user.id,
+      email: user.email,
+      first_name: user.first_name,
+      last_name: user.last_name
+    })
+    assert_equal(expected_normal_view,
+                 ViewUserSerializer.render(user, view: :normal))
   end
 
+  test 'model serializer with associations' do
+    SimpleVehicleSerializer = Class.new(PaintedRabbit::Base) do
+      identifier :id
+      fields :make, :model
+
+      include_in :extended do
+        field :miles
+      end
+    end
+
+    UserSerializer = Class.new(PaintedRabbit::Base) do
+      identifier :id
+      field :email
+      fields :last_name, :first_name
+
+      include_in :normal do
+        association :vehicles, serializer: SimpleVehicleSerializer
+      end
+    end
+
+    user = create(:user)
+    vehicle = create(:vehicle, user: user)
+
+    expected_result = JSON.generate({
+      id: user.id,
+      email: user.email,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      vehicles: [ {
+        id: vehicle.id,
+        make: vehicle.make,
+        model: vehicle.model
+      }]
+    })
+    assert_equal(expected_result, UserSerializer.render(user, view: :normal))
+  end
+
+  test 'model serializer with associations with views' do
+    VehicleViewSerializer = Class.new(PaintedRabbit::Base) do
+      identifier :id
+      fields :make, :model
+
+      include_in :extended do
+        field :miles
+      end
+    end
+
+    UserAssociationSerializer = Class.new(PaintedRabbit::Base) do
+      identifier :id
+      field :email
+      fields :last_name, :first_name
+
+      include_in :normal do
+        association :vehicles, serializer: VehicleViewSerializer, view: :extended
+      end
+    end
+
+    user = create(:user)
+    vehicle = create(:vehicle, user: user)
+
+    expected_result = JSON.generate({
+      id: user.id,
+      email: user.email,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      vehicles: [ {
+        id: vehicle.id,
+        make: vehicle.make,
+        miles: vehicle.miles,
+        model: vehicle.model
+      }]
+    })
+    assert_equal(expected_result, UserAssociationSerializer.render(user, view: :normal))
+  end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -5,7 +5,7 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
 
   test 'simple model serializer' do
-    SimpleUserSerializer = Class.new(PaintedRabbit::Base) do
+    simple_user_serializer_class = Class.new(PaintedRabbit::Base) do
       identifier :id
       field :email
       fields :last_name, :first_name
@@ -20,11 +20,11 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       last_name: user.last_name
     })
 
-    assert_equal(expected_result, SimpleUserSerializer.render(user))
+    assert_equal(expected_result, simple_user_serializer_class.render(user))
   end
 
   test 'model serializer with views' do
-    ViewUserSerializer = Class.new(PaintedRabbit::Base) do
+    view_user_serializer_class = Class.new(PaintedRabbit::Base) do
       identifier :id
       field :email
 
@@ -39,19 +39,20 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       id: user.id,
       email: user.email
     })
-    assert_equal(expected_default_view, ViewUserSerializer.render(user))
     expected_normal_view = JSON.generate({
       id: user.id,
       email: user.email,
       first_name: user.first_name,
       last_name: user.last_name
     })
+
+    assert_equal(expected_default_view, view_user_serializer_class.render(user))
     assert_equal(expected_normal_view,
-                 ViewUserSerializer.render(user, view: :normal))
+                 view_user_serializer_class.render(user, view: :normal))
   end
 
   test 'model serializer with associations' do
-    SimpleVehicleSerializer = Class.new(PaintedRabbit::Base) do
+    simple_vehicle_serializer_class = Class.new(PaintedRabbit::Base) do
       identifier :id
       fields :make, :model
 
@@ -60,13 +61,13 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       end
     end
 
-    UserSerializer = Class.new(PaintedRabbit::Base) do
+    user_serializer_class = Class.new(PaintedRabbit::Base) do
       identifier :id
       field :email
       fields :last_name, :first_name
 
       include_in :normal do
-        association :vehicles, serializer: SimpleVehicleSerializer
+        association :vehicles, serializer: simple_vehicle_serializer_class
       end
     end
 
@@ -84,11 +85,11 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
         model: vehicle.model
       }]
     })
-    assert_equal(expected_result, UserSerializer.render(user, view: :normal))
+    assert_equal(expected_result, user_serializer_class.render(user, view: :normal))
   end
 
   test 'model serializer with associations with views' do
-    VehicleViewSerializer = Class.new(PaintedRabbit::Base) do
+    vehicle_view_serializer_class = Class.new(PaintedRabbit::Base) do
       identifier :id
       fields :make, :model
 
@@ -97,13 +98,13 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       end
     end
 
-    UserAssociationSerializer = Class.new(PaintedRabbit::Base) do
+    user_association_serializer_class = Class.new(PaintedRabbit::Base) do
       identifier :id
       field :email
       fields :last_name, :first_name
 
       include_in :normal do
-        association :vehicles, serializer: VehicleViewSerializer, view: :extended
+        association :vehicles, serializer: vehicle_view_serializer_class, view: :extended
       end
     end
 
@@ -122,6 +123,6 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
         model: vehicle.model
       }]
     })
-    assert_equal(expected_result, UserAssociationSerializer.render(user, view: :normal))
+    assert_equal(expected_result, user_association_serializer_class.render(user, view: :normal))
   end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,0 +1,34 @@
+require 'rails_test_helper'
+require_relative 'factories/model_factories.rb'
+
+class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
+  include FactoryGirl::Syntax::Methods
+
+  test 'simple model serializer' do
+    SimpleUserSerializer = Class.new(PaintedRabbit::Base) do
+      identifier :id
+      field :email
+      fields :last_name, :first_name
+    end
+
+    user = create(:user)
+
+    expected_result = JSON.generate({
+      id: user.id,
+      email: user.email,
+      first_name: user.first_name,
+      last_name: user.last_name
+    })
+
+    assert_equal(expected_result, SimpleUserSerializer.render(user))
+  end
+
+  test 'model serializer with views' do
+    ViewUserSerializer = Class.new(PaintedRabbit::Base) do
+      identifier :id
+      field :email
+      fields :last_name, :first_name
+    end
+  end
+
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  has_many :vehicles
 end

--- a/test/dummy/app/models/vehicle.rb
+++ b/test/dummy/app/models/vehicle.rb
@@ -1,0 +1,3 @@
+class Vehicle < ApplicationRecord
+  belongs_to :user
+end

--- a/test/dummy/db/migrate/20170809211229_create_users.rb
+++ b/test/dummy/db/migrate/20170809211229_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.string :first_name
+      t.string :last_name
+      t.string :email
+      t.text :address
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20170830212110_create_vehicles.rb
+++ b/test/dummy/db/migrate/20170830212110_create_vehicles.rb
@@ -1,0 +1,12 @@
+class CreateVehicles < ActiveRecord::Migration[5.1]
+  def change
+    create_table :vehicles do |t|
+      t.string :make
+      t.string :model
+      t.integer :miles
+      t.references :user
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20170809211229) do
+
+  create_table "users", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.text "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170809211229) do
+ActiveRecord::Schema.define(version: 20170830212110) do
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"
@@ -19,6 +19,16 @@ ActiveRecord::Schema.define(version: 20170809211229) do
     t.text "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "vehicles", force: :cascade do |t|
+    t.string "make"
+    t.string "model"
+    t.integer "miles"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_vehicles_on_user_id"
   end
 
 end

--- a/test/factories/model_factories.rb
+++ b/test/factories/model_factories.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :user do
+    first_name "Meg"
+    last_name  "Jones"
+    email 'fake@fake.org'
+    address = "123 Fake Street\n" +
+      "Fakesville, OH 12345"
+  end
+end

--- a/test/factories/model_factories.rb
+++ b/test/factories/model_factories.rb
@@ -6,4 +6,11 @@ FactoryGirl.define do
     address = "123 Fake Street\n" +
       "Fakesville, OH 12345"
   end
+
+  factory :vehicle do
+    make 'Harper'
+    model 'Invacar'
+    miles { rand(1..500000) }
+    association :user
+  end
 end

--- a/test/painted_rabbit_test.rb
+++ b/test/painted_rabbit_test.rb
@@ -1,30 +1,32 @@
 require 'test_helper'
 require 'ostruct'
-class PaintedRabbit::Test < ActiveSupport::TestCase
-  test "truth" do
+
+class PaintedRabbit::Test < Minitest::Test
+
+  def test_truth
     assert_kind_of Module, PaintedRabbit
   end
 
-  test "it renders based on a templates class" do
+  def test_templates_class
     my_obj = OpenStruct.new(id: 1, name: 'Meg')
-    SimpleRabbit = Class.new(PaintedRabbit::Base) do
+    simple_rabbit = Class.new(PaintedRabbit::Base) do
       field :id
       field :name
     end
-    assert_equal('{"id":1,"name":"Meg"}', SimpleRabbit.render(my_obj))
+    assert_equal('{"id":1,"name":"Meg"}', simple_rabbit.render(my_obj))
   end
 
-  test "it can rename keys" do
+  def test_renaming_keys
     my_obj = OpenStruct.new(id: 1, name: 'Meg')
-    RenameRabbit = Class.new(PaintedRabbit::Base) do
+    rename_rabbit = Class.new(PaintedRabbit::Base) do
       field :id, name: :identifier
       field :name
     end
-    assert_equal('{"identifier":1,"name":"Meg"}', RenameRabbit.render(my_obj))
+    assert_equal('{"identifier":1,"name":"Meg"}', rename_rabbit.render(my_obj))
   end
 
-  test "fields can use custom serializers" do
-    UpcaseSerializer = Class.new(PaintedRabbit::Serializer) do
+  def test_fields_using_custom_serializers
+    upcase_serializer = Class.new(PaintedRabbit::Serializer) do
       # TODO: this API sucks, just pass the value.
       # It has a place internally and for complicated uses, but should be wrapped.
       serialize do |field_name, object|
@@ -33,14 +35,14 @@ class PaintedRabbit::Test < ActiveSupport::TestCase
     end
     my_obj = OpenStruct.new(id: 1, name: 'Meg')
 
-    UpcaseRabbit = Class.new(PaintedRabbit::Base) do
+    upcase_rabbit = Class.new(PaintedRabbit::Base) do
       field :id
-      field :name, serializer: UpcaseSerializer
+      field :name, serializer: upcase_serializer
     end
-    assert_equal('{"id":1,"name":"MEG"}', UpcaseRabbit.render(my_obj))
+    assert_equal('{"id":1,"name":"MEG"}', upcase_rabbit.render(my_obj))
   end
 
-  test "it can take an array of fields" do
+  def test_accepts_array_of_fields
     my_obj = OpenStruct.new(id: 1, name: 'Meg', description: 'A person')
     my_klass = Class.new(PaintedRabbit::Base) do
       identifier :id
@@ -49,7 +51,7 @@ class PaintedRabbit::Test < ActiveSupport::TestCase
     assert_equal('{"id":1,"description":"A person","name":"Meg"}', my_klass.render(my_obj))
   end
 
-  test "it supports views" do
+  def test_views
     my_obj = OpenStruct.new(id: 1, name: 'Meg', position: 'Manager', description: 'A person', 'company': 'Procore')
     view_klass = Class.new(PaintedRabbit::Base) do
       identifier :id

--- a/test/painted_rabbit_test.rb
+++ b/test/painted_rabbit_test.rb
@@ -9,20 +9,20 @@ class PaintedRabbit::Test < Minitest::Test
 
   def test_templates_class
     my_obj = OpenStruct.new(id: 1, name: 'Meg')
-    simple_rabbit = Class.new(PaintedRabbit::Base) do
+    simple_rabbit_class = Class.new(PaintedRabbit::Base) do
       field :id
       field :name
     end
-    assert_equal('{"id":1,"name":"Meg"}', simple_rabbit.render(my_obj))
+    assert_equal('{"id":1,"name":"Meg"}', simple_rabbit_class.render(my_obj))
   end
 
   def test_renaming_keys
     my_obj = OpenStruct.new(id: 1, name: 'Meg')
-    rename_rabbit = Class.new(PaintedRabbit::Base) do
+    rename_rabbit_class = Class.new(PaintedRabbit::Base) do
       field :id, name: :identifier
       field :name
     end
-    assert_equal('{"identifier":1,"name":"Meg"}', rename_rabbit.render(my_obj))
+    assert_equal('{"identifier":1,"name":"Meg"}', rename_rabbit_class.render(my_obj))
   end
 
   def test_fields_using_custom_serializers
@@ -35,11 +35,11 @@ class PaintedRabbit::Test < Minitest::Test
     end
     my_obj = OpenStruct.new(id: 1, name: 'Meg')
 
-    upcase_rabbit = Class.new(PaintedRabbit::Base) do
+    upcase_rabbit_class = Class.new(PaintedRabbit::Base) do
       field :id
       field :name, serializer: upcase_serializer
     end
-    assert_equal('{"id":1,"name":"MEG"}', upcase_rabbit.render(my_obj))
+    assert_equal('{"id":1,"name":"MEG"}', upcase_rabbit_class.render(my_obj))
   end
 
   def test_accepts_array_of_fields

--- a/test/rails_test_helper.rb
+++ b/test/rails_test_helper.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
+ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
+require "rails/test_help"
+
+Rails::TestUnitReporter.executable = 'bin/test'
+
+# Load fixtures from the engine
+if ActiveSupport::TestCase.respond_to?(:fixture_path=)
+  ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
+  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
+  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
+  ActiveSupport::TestCase.fixtures :all
+end

--- a/test/rails_test_helper.rb
+++ b/test/rails_test_helper.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
 require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
+Rails.env = 'test'
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 require "rails/test_help"
 
 Rails::TestUnitReporter.executable = 'bin/test'
+
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,17 +1,10 @@
-require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
-require "rails/test_help"
+gem 'minitest', '~> 5.10'
+require 'minitest/autorun'
+require 'painted_rabbit'
+require 'factory_girl'
+
+#require "rails/test_help"
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
-
-Rails::TestUnitReporter.executable = 'bin/test'
-
-# Load fixtures from the engine
-if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
-  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
-  ActiveSupport::TestCase.fixtures :all
-end


### PR DESCRIPTION
*What this PR accomplishes:*

* Support for nested serializers & views for associations
  e.g. `association :vehicles, serializer: VehicleViewSerializer, view: :extended`
* Extended tests for associations and Active Record lookups
* Removes ActiveRecord as a foundational requirement for the serializer
* Removes our dependency on ActiveRecord for the base serializer tests, greatly speeding them up