### PR TITLE
Refactors serializers to be simpler and avoid need for blehs and blahs

### DIFF
--- a/lib/painted_rabbit/base.rb
+++ b/lib/painted_rabbit/base.rb
@@ -8,7 +8,7 @@ require_relative 'serializers/public_send_serializer'
 module PaintedRabbit
   class Base
     def self.identifier(method, name: method, serializer: PublicSendSerializer)
-      views[:identifier] = { name: Field.new(method, name, serializer.bleh) }
+      views[:identifier] = { name: Field.new(method, name, serializer) }
     end
 
     def self.field(method, options = {})
@@ -16,7 +16,7 @@ module PaintedRabbit
       serializer = options.delete(:serializer) || AssociationSerializer
       current_views.each do |view_name|
         views[view_name] ||= {}
-        views[view_name][name] = Field.new(method, name, serializer.bleh, options)
+        views[view_name][name] = Field.new(method, name, serializer, options)
       end
     end
 
@@ -28,7 +28,7 @@ module PaintedRabbit
         views[view_name] ||= {}
         views[view_name][name] = Field.new(method,
                                            name,
-                                           AssociationSerializer.bleh,
+                                           AssociationSerializer,
                                            options.merge(association: true))
       end
     end
@@ -58,7 +58,7 @@ module PaintedRabbit
       field_names.each do |field_name|
         current_views.each do |view_name|
           views[view_name] ||= {}
-          views[view_name][field_name] = Field.new(field_name, field_name, PublicSendSerializer.bleh)
+          views[view_name][field_name] = Field.new(field_name, field_name, PublicSendSerializer)
         end
       end
     end
@@ -77,7 +77,7 @@ module PaintedRabbit
 
     def self.object_to_hash(object, view:)
       render_fields(view).each_with_object({}) do |field, hash|
-        hash[field.name] = field.serializer.call(field.method, object, field.options)
+        hash[field.name] = field.serializer.serialize(field.method, object, field.options)
       end
     end
     private_class_method :object_to_hash

--- a/lib/painted_rabbit/serializer.rb
+++ b/lib/painted_rabbit/serializer.rb
@@ -1,16 +1,12 @@
 class PaintedRabbit::Serializer
-  def initialize(block)
-    @block = block
-  end
-  def self.serialize(&block)
-    @_blah = self.new(block)
+  def initialize
   end
 
-  def self.bleh
-    @_blah
+  def serialize(field_name, object, options={})
+    fail NotImplementedError, "A serializer must implement #serialize"
   end
 
-  def call(field_name, object, options={})
-    @block.call(field_name, object, options)
+  def self.serialize(field_name, object, options={})
+    self.new.serialize(field_name, object, options)
   end
 end

--- a/lib/painted_rabbit/serializers/association_serializer.rb
+++ b/lib/painted_rabbit/serializers/association_serializer.rb
@@ -1,5 +1,5 @@
 class PaintedRabbit::AssociationSerializer < PaintedRabbit::Serializer
-  serialize do |association_name, object, options={}|
+  def serialize(association_name, object, options={})
     if options[:serializer]
       view = options[:view] || :default
       options[:serializer].prepare(object.public_send(association_name), view: view)

--- a/lib/painted_rabbit/serializers/public_send_serializer.rb
+++ b/lib/painted_rabbit/serializers/public_send_serializer.rb
@@ -1,5 +1,5 @@
 class PaintedRabbit::PublicSendSerializer < PaintedRabbit::Serializer
-  serialize do |field_name, object|
+  def serialize(field_name, object, options = {})
     object.public_send(field_name)
   end
 end

--- a/test/painted_rabbit_test.rb
+++ b/test/painted_rabbit_test.rb
@@ -27,9 +27,7 @@ class PaintedRabbit::Test < Minitest::Test
 
   def test_fields_using_custom_serializers
     upcase_serializer = Class.new(PaintedRabbit::Serializer) do
-      # TODO: this API sucks, just pass the value.
-      # It has a place internally and for complicated uses, but should be wrapped.
-      serialize do |field_name, object|
+      def serialize(field_name, object, options={})
         object.public_send(field_name).upcase
       end
     end


### PR DESCRIPTION
### What this PR does
Simplifies the logic of field serializers, placing all the magic into a method (that must be implemented) called `serializer`

### Rationale
We had a confusing interface for field serializers implementing their logic in a `&block` and then relying on `bleh` and `blah` to implement.