### PR TITLE
ActiveRecord::Relation detection

### DIFF
--- a/lib/painted_rabbit/base.rb
+++ b/lib/painted_rabbit/base.rb
@@ -83,9 +83,7 @@ module PaintedRabbit
     private_class_method :object_to_hash
 
     def self.select_columns(object, view:)
-      unless object.is_a?(ActiveRecord::Base) && object.respond_to?(:klass)
-        return object
-      end
+      return object unless object.is_a?(ActiveRecord::Relation)
       select_columns = (active_record_attributes(object) &
         render_fields(view).map(&:method)) +
         required_lookup_attributes(object)
@@ -94,9 +92,7 @@ module PaintedRabbit
     private_class_method :select_columns
 
     def self.include_associations(object, view:)
-      unless object.is_a?(ActiveRecord::Base) && object.respond_to?(:klass)
-        return object
-      end
+      return object unless object.is_a?(ActiveRecord::Relation)
       # TODO: Do we need to support more than `eager_load` ?
       fields_to_include = associations(view).select { |a|
         a.options[:include] != false


### PR DESCRIPTION
This code never will resolve to true:
```
unless object.is_a?(ActiveRecord::Base) && object.respond_to?(:klass)
  return object
end
```

An `ActiveRecord::Base` object does not have a `#klass` method. The
`#klass` method is found only in `ActiveRecord::Relation`.

I'm assuming that based on the following code, that what we are trying
to detect is an `ActiveRecord::Relation` object. So I added this
instead `object.is_a?(ActiveRecord::Relation)`.