### PR TITLE
Implement an improved View interface

### DIFF
--- a/lib/painted_rabbit/base.rb
+++ b/lib/painted_rabbit/base.rb
@@ -57,25 +57,27 @@ module PaintedRabbit
     end
 
     def self.associations(view = :default)
-      views.render_fields(view).select { |f| f.options[:association] }
+      views.fields_for(view).select { |f| f.options[:association] }
     end
 
     def self.include_view(view)
+      current_view.included_views << view
     end
 
     def self.exclude(field_name)
+      current_view.excluded_fields << field_name
     end
 
     def self.view(view_name)
-      current_view = views[view_name]
+      @current_view = views[view_name]
       yield
-      current_view = views[:default]
+      @current_view = views[:default]
     end
 
     private
 
     def self.object_to_hash(object, view:)
-      views.render_fields(view).each_with_object({}) do |field, hash|
+      views.fields_for(view).each_with_object({}) do |field, hash|
         hash[field.name] = field.serializer.serialize(field.method, object, field.options)
       end
     end
@@ -88,7 +90,7 @@ module PaintedRabbit
         return object
       end
       select_columns = (active_record_attributes(object) &
-        views.render_fields(view).map(&:method)) +
+        views.fields_for(view).map(&:method)) +
         required_lookup_attributes(object)
       object.select(*select_columns)
     end

--- a/lib/painted_rabbit/base.rb
+++ b/lib/painted_rabbit/base.rb
@@ -2,35 +2,31 @@ require 'json'
 require_relative 'painted_rabbit_error'
 require_relative 'field'
 require_relative 'serializer'
+require_relative 'view'
+require_relative 'view_collection'
 require_relative 'serializers/association_serializer'
 require_relative 'serializers/public_send_serializer'
 
 module PaintedRabbit
   class Base
     def self.identifier(method, name: method, serializer: PublicSendSerializer)
-      views[:identifier] = { name: Field.new(method, name, serializer) }
+      views[:identifier] << Field.new(method, name, serializer)
     end
 
     def self.field(method, options = {})
       name = options.delete(:name) || method
       serializer = options.delete(:serializer) || AssociationSerializer
-      current_views.each do |view_name|
-        views[view_name] ||= {}
-        views[view_name][name] = Field.new(method, name, serializer, options)
-      end
+      current_view << Field.new(method, name, serializer, options)
     end
 
     # Options:
     #   preload: Set to false to stop trying to eagerly load associations
     def self.association(method, options = {})
       name = options.delete(:name) || method
-      current_views.each do |view_name|
-        views[view_name] ||= {}
-        views[view_name][name] = Field.new(method,
-                                           name,
-                                           AssociationSerializer,
-                                           options.merge(association: true))
-      end
+      current_view << Field.new(method,
+                                       name,
+                                       AssociationSerializer,
+                                       options.merge(association: true))
     end
 
     def self.render(object, view: :default)
@@ -40,7 +36,7 @@ module PaintedRabbit
     # This is the magic method that converts complex objects into a simple hash
     # ready for JSON conversion
     def self.prepare(object, view:)
-      unless views.keys.include? view
+      unless views.has_view? view
         raise PaintedRabbitError, "View '#{view}' is not defined"
       end
       prepared_object = select_columns(object, view: view)
@@ -56,45 +52,52 @@ module PaintedRabbit
 
     def self.fields(*field_names)
       field_names.each do |field_name|
-        current_views.each do |view_name|
-          views[view_name] ||= {}
-          views[view_name][field_name] = Field.new(field_name, field_name, PublicSendSerializer)
-        end
+        current_view << Field.new(field_name, field_name, PublicSendSerializer)
       end
     end
 
     def self.associations(view = :default)
-      render_fields(view).select { |f| f.options[:association] }
+      views.render_fields(view).select { |f| f.options[:association] }
     end
 
-    def self.include_in(view_list)
-      @current_views = Array(view_list)
+    def self.include_view(view)
+    end
+
+    def self.exclude(field_name)
+    end
+
+    def self.view(view_name)
+      current_view = views[view_name]
       yield
-      current_views = [:default]
+      current_view = views[:default]
     end
 
     private
 
     def self.object_to_hash(object, view:)
-      render_fields(view).each_with_object({}) do |field, hash|
+      views.render_fields(view).each_with_object({}) do |field, hash|
         hash[field.name] = field.serializer.serialize(field.method, object, field.options)
       end
     end
     private_class_method :object_to_hash
 
     def self.select_columns(object, view:)
-      unless object.is_a?(ActiveRecord::Base) && object.respond_to?(:klass)
+      unless defined?(ActiveRecord::Base) &&
+          object.is_a?(ActiveRecord::Base) &&
+          object.respond_to?(:klass)
         return object
       end
       select_columns = (active_record_attributes(object) &
-        render_fields(view).map(&:method)) +
+        views.render_fields(view).map(&:method)) +
         required_lookup_attributes(object)
       object.select(*select_columns)
     end
     private_class_method :select_columns
 
     def self.include_associations(object, view:)
-      unless object.is_a?(ActiveRecord::Base) && object.respond_to?(:klass)
+      unless defined?(ActiveRecord::Base) &&
+          object.is_a?(ActiveRecord::Base) &&
+          object.respond_to?(:klass)
         return object
       end
       # TODO: Do we need to support more than `eager_load` ?
@@ -113,12 +116,6 @@ module PaintedRabbit
       object.klass.column_names.map(&:to_sym)
     end
     private_class_method :active_record_attributes
-
-    def self.render_fields(view)
-      views[:identifier].values +
-        views[:default].merge(views[view]).values.sort_by(&:name)
-    end
-    private_class_method :render_fields
 
     # Find all the attributes required for includes & eager/pre-loading
     def self.required_lookup_attributes(object)
@@ -142,13 +139,13 @@ module PaintedRabbit
     end
     private_class_method :jsonify
 
-    def self.current_views
-      @current_views ||= [:default]
+    def self.current_view
+      @current_view ||= views[:default]
     end
-    private_class_method :current_views
+    private_class_method :current_view
 
     def self.views
-      @views ||= { identifier: {}, default: {} }
+      @views ||= ViewCollection.new
     end
     private_class_method :views
   end

--- a/lib/painted_rabbit/view.rb
+++ b/lib/painted_rabbit/view.rb
@@ -2,8 +2,9 @@ module PaintedRabbit
   class View
     attr_reader :fields, :included_view_names, :excluded_field_names
 
-    def initialize
-      @fields = []
+    def initialize(name)
+      @name = name
+      @fields = {}
       @included_view_names = []
       @excluded_field_names = []
     end
@@ -17,7 +18,11 @@ module PaintedRabbit
     end
 
     def <<(field)
-      @fields << field
+      if @fields.has_key? field
+        raise PaintedRabbitError,
+          "Field #{field.name} already defined on #{@name}"
+      end
+      @fields[field.name] = field
     end
   end
 end

--- a/lib/painted_rabbit/view.rb
+++ b/lib/painted_rabbit/view.rb
@@ -1,0 +1,14 @@
+module PaintedRabbit
+  class View
+    attr_reader :fields
+
+    def initialize
+      @fields = []
+    end
+
+    def <<(field)
+      @fields << field
+    end
+
+  end
+end

--- a/lib/painted_rabbit/view.rb
+++ b/lib/painted_rabbit/view.rb
@@ -1,11 +1,19 @@
 module PaintedRabbit
   class View
-    attr_reader :fields, :included_views, :excluded_fields
+    attr_reader :fields, :included_view_names, :excluded_field_names
 
     def initialize
       @fields = []
-      @included_views = []
-      @excluded_fields = []
+      @included_view_names = []
+      @excluded_field_names = []
+    end
+
+    def include_view(view_name)
+      @included_view_names << view_name
+    end
+
+    def exclude_field(field_name)
+      @excluded_field_names << field_name
     end
 
     def <<(field)

--- a/lib/painted_rabbit/view.rb
+++ b/lib/painted_rabbit/view.rb
@@ -1,14 +1,15 @@
 module PaintedRabbit
   class View
-    attr_reader :fields
+    attr_reader :fields, :included_views, :excluded_fields
 
     def initialize
       @fields = []
+      @included_views = []
+      @excluded_fields = []
     end
 
     def <<(field)
       @fields << field
     end
-
   end
 end

--- a/lib/painted_rabbit/view_collection.rb
+++ b/lib/painted_rabbit/view_collection.rb
@@ -29,13 +29,13 @@ module PaintedRabbit
     def sortable_fields(view_name)
       fields = views[:default].fields
       fields += views[view_name].fields
-      views[view_name].included_views.each do |included_view_name|
+      views[view_name].included_view_names.each do |included_view_name|
         if view_name != included_view_name
           fields += sortable_fields(included_view_name)
         end
       end
       fields.delete_if do |f|
-        views[view_name].excluded_fields.include? f.name
+        views[view_name].excluded_field_names.include? f.name
       end
     end
   end

--- a/lib/painted_rabbit/view_collection.rb
+++ b/lib/painted_rabbit/view_collection.rb
@@ -1,0 +1,24 @@
+module PaintedRabbit
+  class ViewCollection
+    attr_reader :views
+    def initialize
+      @views = {
+        identifier: View.new,
+        default: View.new
+      }
+    end
+
+    def has_view?(view_name)
+      views.has_key? view_name
+    end
+
+    def render_fields(key)
+      views[:identifier].fields +
+        views[:default].fields.concat(views[key].fields).sort_by(&:name)
+    end
+
+    def [](key)
+      @views[key] ||= View.new
+    end
+  end
+end

--- a/lib/painted_rabbit/view_collection.rb
+++ b/lib/painted_rabbit/view_collection.rb
@@ -12,13 +12,31 @@ module PaintedRabbit
       views.has_key? view_name
     end
 
-    def render_fields(key)
-      views[:identifier].fields +
-        views[:default].fields.concat(views[key].fields).sort_by(&:name)
+    def fields_for(view_name)
+      identifier_fields + sortable_fields(view_name).sort_by(&:name)
     end
 
-    def [](key)
-      @views[key] ||= View.new
+    def [](view_name)
+      @views[view_name] ||= View.new
+    end
+
+    private
+
+    def identifier_fields
+      views[:identifier].fields
+    end
+
+    def sortable_fields(view_name)
+      fields = views[:default].fields
+      fields += views[view_name].fields
+      views[view_name].included_views.each do |included_view_name|
+        if view_name != included_view_name
+          fields += sortable_fields(included_view_name)
+        end
+      end
+      fields.delete_if do |f|
+        views[view_name].excluded_fields.include? f.name
+      end
     end
   end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -28,7 +28,7 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       identifier :id
       field :email
 
-      include_in :normal do
+      view :normal do
         fields :last_name, :first_name
       end
     end
@@ -56,7 +56,7 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       identifier :id
       fields :make, :model
 
-      include_in :extended do
+      view :extended do
         field :miles
       end
     end
@@ -66,7 +66,7 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       field :email
       fields :last_name, :first_name
 
-      include_in :normal do
+      view :normal do
         association :vehicles, serializer: simple_vehicle_serializer_class
       end
     end
@@ -93,7 +93,7 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       identifier :id
       fields :make, :model
 
-      include_in :extended do
+      view :extended do
         field :miles
       end
     end
@@ -103,7 +103,7 @@ class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase
       field :email
       fields :last_name, :first_name
 
-      include_in :normal do
+      view :normal do
         association :vehicles, serializer: vehicle_view_serializer_class, view: :extended
       end
     end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,4 +1,4 @@
-require 'rails_test_helper'
+require_relative 'rails_test_helper'
 require_relative 'factories/model_factories.rb'
 
 class PaintedRabbit::ActiveRecordTest < ActiveSupport::TestCase

--- a/test/painted_rabbit_test.rb
+++ b/test/painted_rabbit_test.rb
@@ -67,14 +67,14 @@ class PaintedRabbit::Test < Minitest::Test
       end
     end
     assert_equal(
-      '{"id":1}',
-      view_klass.render(my_obj),
-      'The default view should render the right fields'
-    )
-    assert_equal(
       '{"id":1,"employer":"Procore","name":"Meg","position":"Manager"}',
       view_klass.render(my_obj, view: :normal),
       'The normal view should render the right fields'
+    )
+    assert_equal(
+      '{"id":1}',
+      view_klass.render(my_obj),
+      'The default view should render the right fields'
     )
     assert_equal(
       '{"id":1,"description":"A person","employer":"Procore","name":"Meg","position":"Manager"}',

--- a/test/painted_rabbit_test.rb
+++ b/test/painted_rabbit_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative 'test_helper'
 require 'ostruct'
 
 class PaintedRabbit::Test < Minitest::Test
@@ -53,16 +53,38 @@ class PaintedRabbit::Test < Minitest::Test
     my_obj = OpenStruct.new(id: 1, name: 'Meg', position: 'Manager', description: 'A person', 'company': 'Procore')
     view_klass = Class.new(PaintedRabbit::Base) do
       identifier :id
-      include_in [:normal, :extended] do
+      view :normal do
         fields :name, :position
         field :company, name: :employer
       end
-      include_in :extended do
+      view :extended do
+        include_view :normal
         field :description
       end
+      view :special do
+        include_view :extended
+        exclude :position
+      end
     end
-    assert_equal('{"id":1}', view_klass.render(my_obj))
-    assert_equal('{"id":1,"employer":"Procore","name":"Meg","position":"Manager"}', view_klass.render(my_obj, view: :normal))
-    assert_equal('{"id":1,"description":"A person","employer":"Procore","name":"Meg","position":"Manager"}', view_klass.render(my_obj, view: :extended))
+    assert_equal(
+      '{"id":1}',
+      view_klass.render(my_obj),
+      'The default view should render the right fields'
+    )
+    assert_equal(
+      '{"id":1,"employer":"Procore","name":"Meg","position":"Manager"}',
+      view_klass.render(my_obj, view: :normal),
+      'The normal view should render the right fields'
+    )
+    assert_equal(
+      '{"id":1,"description":"A person","employer":"Procore","name":"Meg","position":"Manager"}',
+      view_klass.render(my_obj, view: :extended),
+      'The extended view should render the right fields'
+    )
+    assert_equal(
+      '{"id":1,"description":"A person","employer":"Procore","name":"Meg"}',
+      view_klass.render(my_obj, view: :special),
+      'The special view should render the right fields'
+    )
   end
 end


### PR DESCRIPTION
This PR changes the format of defining views from:
```ruby
identifier :id
field :name
include_in [:normal, :extended] do
  field :description
end
include_in :extended do
  field :color
end
```
to
```ruby
identifier :id
field :name
view :normal do
  field :description
end
view :extended do
  incldue_view :normal
  field :color
end
```

And also implements the ability to exclude fields from views using the interface `exclude :field_name`