### PR TITLE
Gemspec fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     painted_rabbit (0.1.0)
+      json
 
 GEM
   remote: https://rubygems.org/
@@ -52,7 +53,7 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
-    json (2.0.3)
+    json (2.1.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -114,10 +115,9 @@ PLATFORMS
 
 DEPENDENCIES
   factory_girl
-  json
   painted_rabbit!
   rails (~> 5.1.2)
   sqlite3
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/painted_rabbit.gemspec
+++ b/painted_rabbit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", "~> 5.1.2"
 
-  s.add_development_dependency "json"
+  s.add_runtime_dependency "json"
 
   s.add_development_dependency "sqlite3"
 end

--- a/painted_rabbit.gemspec
+++ b/painted_rabbit.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_development_dependency "rails", "~> 5.1.2"
+  s.add_development_dependency "sqlite3"
 
   s.add_runtime_dependency "json"
-
-  s.add_development_dependency "sqlite3"
 end

--- a/painted_rabbit.gemspec
+++ b/painted_rabbit.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
+  s.required_ruby_version = '>= 2.2.2'
+
   s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "sqlite3"
 


### PR DESCRIPTION
    JSON should be a runtime dependency and not just a development
    dependency.

    We are using required keyword arguments in a number of places
    which is a ruby 2.1+ feature.
 
    Additionally, we are using ruby 2.2.2 and above libraries in development
    so to stay safe, we will require ruby 2.2.2 in the gemspec.