### PR TITLE
Benchmark tests #7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,9 +25,16 @@ require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
+  t.test_files = Dir['test/**/*_test.rb'].reject do |path|
+    path.include?('benchmarks')
+  end
   t.verbose = false
 end
 
+Rake::TestTask.new(:benchmarks) do |t|
+  t.libs << 'test'
+  t.pattern = 'test/benchmarks/**/*_test.rb'
+  t.verbose = false
+end
 
 task default: :test

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,4 @@ database:
 test:
   post:
     - bundle exec rake
+    - bundle exec rake benchmarks

--- a/test/benchmarks/active_record_big_o_test.rb
+++ b/test/benchmarks/active_record_big_o_test.rb
@@ -1,0 +1,23 @@
+require_relative '../rails_test_helper'
+require_relative '../factories/model_factories.rb'
+require 'minitest/benchmark'
+
+class PaintedRabbit::ActiveRecordBigOTest < Minitest::Benchmark
+  include FactoryGirl::Syntax::Methods
+
+  def setup
+    @painted_rabbit = Class.new(PaintedRabbit::Base) do
+      identifier :id
+      fields :first_name, :last_name
+    end
+    @prepared_objects = self.class.bench_range.inject({}) do |hash, n|
+      hash.merge n => n.times.map {|i| create(:user)}
+    end
+  end
+
+  def bench_render_active_record
+    assert_performance_linear do |n|
+      @painted_rabbit.render(@prepared_objects[n])
+    end
+  end
+end

--- a/test/benchmarks/active_record_ips_test.rb
+++ b/test/benchmarks/active_record_ips_test.rb
@@ -1,0 +1,21 @@
+require_relative '../rails_test_helper'
+require_relative '../factories/model_factories.rb'
+require_relative 'benchmark_helper'
+
+class PaintedRabbit::ActiveRecordIPSTest < Minitest::Test
+  include FactoryGirl::Syntax::Methods
+  include BenchmarkHelper
+
+  def setup
+    @painted_rabbit = Class.new(PaintedRabbit::Base) do
+      fields :first_name, :last_name
+    end
+    @prepared_objects = 10.times.map {create(:user)}
+  end
+
+  def test_render
+    result = iterate {@painted_rabbit.render(@prepared_objects)}
+    puts "\nActiveRecord IPS: #{result}"
+    assert_operator(result, :>=, 2500)
+  end
+end

--- a/test/benchmarks/benchmark_helper.rb
+++ b/test/benchmarks/benchmark_helper.rb
@@ -1,0 +1,11 @@
+module BenchmarkHelper
+  def iterate(&block)
+    start = Time.now
+    count = 0
+    while Time.now - start <= 1.second do
+      block.call
+      count += 1
+    end
+    count
+  end
+end

--- a/test/benchmarks/big_o_test.rb
+++ b/test/benchmarks/big_o_test.rb
@@ -1,0 +1,21 @@
+require_relative '../test_helper'
+require 'ostruct'
+require 'minitest/benchmark'
+
+class PaintedRabbit::BigOTest < Minitest::Benchmark
+  def setup
+    @painted_rabbit = Class.new(PaintedRabbit::Base) do
+      field :id
+      field :name
+    end
+    @prepared_objects = self.class.bench_range.inject({}) do |hash, n|
+      hash.merge n => n.times.map {|i| OpenStruct.new(id: i, name: "obj #{i}")}
+    end
+  end
+
+  def bench_render_basic
+    assert_performance_linear do |n|
+      @painted_rabbit.render(@prepared_objects[n])
+    end
+  end
+end

--- a/test/benchmarks/ips_test.rb
+++ b/test/benchmarks/ips_test.rb
@@ -1,0 +1,21 @@
+require_relative '../test_helper'
+require_relative 'benchmark_helper'
+require 'ostruct'
+
+class PaintedRabbit::IPSTest < Minitest::Test
+  include BenchmarkHelper
+
+  def setup
+    @painted_rabbit = Class.new(PaintedRabbit::Base) do
+      field :id
+      field :name
+    end
+    @prepared_objects = 10.times.map {|i| OpenStruct.new(id: i, name: "obj #{i}")}
+  end
+
+  def test_render
+    result = iterate {@painted_rabbit.render(@prepared_objects)}
+    puts "\nBasic IPS: #{result}"
+    assert_operator(result, :>=, 3000)
+  end
+end


### PR DESCRIPTION
There are two types of tests; an iterations per second (IPS) test, and a test to see if increasing number of objects passed to `Base#self.render` increases execution time linearly.

We consider both `ActiveRecord` objects and simple objects (`OpenStruct`) when making the tests.

In the IPS tests, we assume that `ActiveRecord` objects will iterate at least 2500 times per second, and an `OpenStruct` object will iterate at least 3000 times per second. Otherwise, the test will fail.

Benchmark tests also only run if you type `bundle exec rake benchmarks`. Default rake will not run the benchmarks.

To see results, open up circle ci, and view the rake benchmarks logs.