### PR TITLE
Use long form style of accessing modules

### DIFF
--- a/lib/painted_rabbit/painted_rabbit_error.rb
+++ b/lib/painted_rabbit/painted_rabbit_error.rb
@@ -1,2 +1,3 @@
-class PaintedRabbit::PaintedRabbitError < StandardError
+module PaintedRabbit
+  class PaintedRabbitError < StandardError; end
 end


### PR DESCRIPTION
Accessing a module through the shorthand method works only if the
module has already been loaded previously. It will NOT define the
module which could easily lead to Uninitialized Constants errors.

Basically, if painted_rabbit_error.rb was loaded first into memory,
it will raise an exeption because the PaintedRabbit module was not
defined.

Our test has not been loading this file first, so we have not
encountered any errors. However, if you wanted to manually require
painted_rabbit.rb into an IRB session, it will erorr.

This long form will fix that and define the PaintedRabbit module if it
has not been loaded.